### PR TITLE
Suggesting switching back to draft

### DIFF
--- a/content/challenges/set-up/ST-BP-blog-from-transcription.md
+++ b/content/challenges/set-up/ST-BP-blog-from-transcription.md
@@ -1,4 +1,5 @@
 ---
+draft       : true
 title       : Write blog post from transcription
 key         : ST-BP
 area        : setup


### PR DESCRIPTION
The links go to the cleaned up versions of the files.
Should this task be recreated to link the original transcripts?