### PR TITLE
fix blog image placeholder not found on live site

### DIFF
--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -13,7 +13,7 @@
                               {{ if .Params.banner }}
                               <img src="{{ .Params.banner }}" class="img-responsive" alt="">
                               {{ else }}
-                              <img src="{{ .Site.BaseURL}}img/placeholder.png" class="img-responsive" alt="">
+                              <img src="{{ "img/placeholder.png" | absURL }}" class="img-responsive" alt="">
                               {{ end }}
                           </a>
                       </div>


### PR DESCRIPTION
use absURL instead of .Site.baseURL interpolation which can lead to broken link when trailing slash is missing